### PR TITLE
17 add settings to enable or disable some rules on demand

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -11,3 +11,25 @@ import (
 func TestAll(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), analyzer.NewAnalyzer(), "simple")
 }
+
+func TestConstructorCheckOnly(t *testing.T) {
+	_ = analyzer.FlagSet.Parse([]string{})
+	if err := analyzer.FlagSet.Set("constructors_check", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := analyzer.FlagSet.Set("struct_methods_check", "false"); err != nil {
+		t.Fatal(err)
+	}
+	analysistest.Run(t, analysistest.TestData(), analyzer.NewAnalyzer(), "constructor_check")
+}
+
+func TestStructMethodsCheckOnly(t *testing.T) {
+	_ = analyzer.FlagSet.Parse([]string{})
+	if err := analyzer.FlagSet.Set("constructors_check", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := analyzer.FlagSet.Set("struct_methods_check", "true"); err != nil {
+		t.Fatal(err)
+	}
+	analysistest.Run(t, analysistest.TestData(), analyzer.NewAnalyzer(), "struct_methods_check")
+}

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -13,23 +13,23 @@ func TestAll(t *testing.T) {
 }
 
 func TestConstructorCheckOnly(t *testing.T) {
-	_ = analyzer.FlagSet.Parse([]string{})
-	if err := analyzer.FlagSet.Set("constructors_check", "true"); err != nil {
+	a := analyzer.NewAnalyzer()
+	if err := a.Flags.Set("constructors_check", "true"); err != nil {
 		t.Fatal(err)
 	}
-	if err := analyzer.FlagSet.Set("struct_methods_check", "false"); err != nil {
+	if err := a.Flags.Set("struct_methods_check", "false"); err != nil {
 		t.Fatal(err)
 	}
-	analysistest.Run(t, analysistest.TestData(), analyzer.NewAnalyzer(), "constructor_check")
+	analysistest.Run(t, analysistest.TestData(), a, "constructor_check")
 }
 
 func TestStructMethodsCheckOnly(t *testing.T) {
-	_ = analyzer.FlagSet.Parse([]string{})
-	if err := analyzer.FlagSet.Set("constructors_check", "false"); err != nil {
+	a := analyzer.NewAnalyzer()
+	if err := a.Flags.Set("constructors_check", "false"); err != nil {
 		t.Fatal(err)
 	}
-	if err := analyzer.FlagSet.Set("struct_methods_check", "true"); err != nil {
+	if err := a.Flags.Set("struct_methods_check", "true"); err != nil {
 		t.Fatal(err)
 	}
-	analysistest.Run(t, analysistest.TestData(), analyzer.NewAnalyzer(), "struct_methods_check")
+	analysistest.Run(t, analysistest.TestData(), a, "struct_methods_check")
 }

--- a/analyzer/testdata/src/constructor_check/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/constructor_check/constructors_after_struct_methods.go
@@ -1,0 +1,24 @@
+package simple
+
+//nolint:recvcheck // testing linter
+type MyStruct2 struct {
+	Name string
+}
+
+func (m MyStruct2) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct2) SetName(name string) {
+	m.Name = name
+}
+
+//nolint:nonamedreturns // testing linter
+func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor \"NewOtherMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	m = &MyStruct2{Name: "John"}
+	return
+}
+
+func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	return &MyStruct2{Name: "John"}
+}

--- a/analyzer/testdata/src/constructor_check/constructors_before_struct.go
+++ b/analyzer/testdata/src/constructor_check/constructors_before_struct.go
@@ -1,0 +1,32 @@
+package simple
+
+//nolint:nonamedreturns // testing linter
+func NewOtherMyStruct() (m *MyStruct) { // want "should be placed after the struct declaration"
+	m = &MyStruct{Name: "John"}
+	return
+}
+
+func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration"
+	return &MyStruct{Name: "John"}
+}
+
+func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration`
+	return NewMyStruct()
+}
+
+//nolint:recvcheck // testing linter
+type MyStruct struct {
+	Name string
+}
+
+func (m MyStruct) lenName() int {
+	return len(m.Name)
+}
+
+func (m MyStruct) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct) SetName(name string) {
+	m.Name = name
+}

--- a/analyzer/testdata/src/constructor_check/struct_not_declared_in_file.go
+++ b/analyzer/testdata/src/constructor_check/struct_not_declared_in_file.go
@@ -1,0 +1,13 @@
+package simple
+
+import (
+	"time"
+)
+
+func NewOtherWayMyStruct() MyStruct {
+	return MyStruct{Name: "John"}
+}
+
+func NewTimeStruct() time.Time {
+	return time.Now()
+}

--- a/analyzer/testdata/src/struct_methods_check/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/struct_methods_check/constructors_after_struct_methods.go
@@ -1,0 +1,24 @@
+package simple
+
+//nolint:recvcheck // testing linter
+type MyStruct2 struct {
+	Name string
+}
+
+func (m MyStruct2) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct2) SetName(name string) {
+	m.Name = name
+}
+
+//nolint:nonamedreturns // testing linter
+func NewOtherMyStruct2() (m *MyStruct2) {
+	m = &MyStruct2{Name: "John"}
+	return
+}
+
+func NewMyStruct2() *MyStruct2 {
+	return &MyStruct2{Name: "John"}
+}

--- a/analyzer/testdata/src/struct_methods_check/constructors_before_struct.go
+++ b/analyzer/testdata/src/struct_methods_check/constructors_before_struct.go
@@ -1,0 +1,32 @@
+package simple
+
+//nolint:nonamedreturns // testing linter
+func NewOtherMyStruct() (m *MyStruct) {
+	m = &MyStruct{Name: "John"}
+	return
+}
+
+func NewMyStruct() *MyStruct {
+	return &MyStruct{Name: "John"}
+}
+
+func MustMyStruct() *MyStruct {
+	return NewMyStruct()
+}
+
+//nolint:recvcheck // testing linter
+type MyStruct struct {
+	Name string
+}
+
+func (m MyStruct) lenName() int { // want `unexported method \"lenName\" for struct \"MyStruct\" should be placed after the exported method \"SetName\"`
+	return len(m.Name)
+}
+
+func (m MyStruct) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct) SetName(name string) {
+	m.Name = name
+}

--- a/analyzer/testdata/src/struct_methods_check/struct_not_declared_in_file.go
+++ b/analyzer/testdata/src/struct_methods_check/struct_not_declared_in_file.go
@@ -1,0 +1,13 @@
+package simple
+
+import (
+	"time"
+)
+
+func NewOtherWayMyStruct() MyStruct {
+	return MyStruct{Name: "John"}
+}
+
+func NewTimeStruct() time.Time {
+	return time.Now()
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,12 @@
+package features
+
+const (
+	ConstructorCheck Feature = 1 << iota
+	StructMethodsCheck
+)
+
+type Feature uint8
+
+func (c Feature) IsEnabled(other Feature) bool {
+	return c&other != 0
+}

--- a/internal/fileprocessor/file_processor.go
+++ b/internal/fileprocessor/file_processor.go
@@ -1,6 +1,7 @@
 package fileprocessor
 
 import (
+	"github.com/manuelarte/funcorder/internal/features"
 	"go/ast"
 
 	"github.com/manuelarte/funcorder/internal/astutils"
@@ -10,13 +11,15 @@ import (
 
 // FileProcessor Holder to store all the functions that are potential to be constructors and all the structs.
 type FileProcessor struct {
-	structs map[string]*models.StructHolder
+	structs  map[string]*models.StructHolder
+	features features.Feature
 }
 
 // NewFileProcessor creates a new file processor.
-func NewFileProcessor() *FileProcessor {
+func NewFileProcessor(checkers features.Feature) *FileProcessor {
 	return &FileProcessor{
-		structs: make(map[string]*models.StructHolder),
+		structs:  make(map[string]*models.StructHolder),
+		features: checkers,
 	}
 }
 
@@ -81,7 +84,7 @@ func (fp *FileProcessor) getOrCreate(structName string) *models.StructHolder {
 	if holder, ok := fp.structs[structName]; ok {
 		return holder
 	}
-	created := &models.StructHolder{}
+	created := &models.StructHolder{Features: fp.features}
 	fp.structs[structName] = created
 	return created
 }

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -4,11 +4,15 @@ import (
 	"go/ast"
 	"sort"
 
+	"github.com/manuelarte/funcorder/internal/features"
+
 	"github.com/manuelarte/funcorder/internal/errors"
 )
 
 // StructHolder contains all the information around a Go struct.
 type StructHolder struct {
+	// The features to be analyzed
+	Features features.Feature
 	// The struct declaration
 	Struct *ast.TypeSpec
 	// A Struct constructor is considered if starts with `New...` and the 1st output parameter is a struct
@@ -25,7 +29,7 @@ func (sh *StructHolder) AddMethod(fn *ast.FuncDecl) {
 	sh.StructMethods = append(sh.StructMethods, fn)
 }
 
-//nolint:gocognit // refactor later
+//nolint:gocognit,nestif // refactor later
 func (sh *StructHolder) Analyze() []errors.LinterError {
 	// TODO maybe sort constructors and then report also, like NewXXX before MustXXX
 	var errs []errors.LinterError
@@ -33,42 +37,46 @@ func (sh *StructHolder) Analyze() []errors.LinterError {
 		return sh.StructMethods[i].Pos() < sh.StructMethods[j].Pos()
 	})
 	structPos := sh.Struct.Pos()
-	for _, c := range sh.Constructors {
-		if c.Pos() < structPos {
-			errs = append(errs, errors.ConstructorNotAfterStructTypeError{
-				Struct:      sh.Struct,
-				Constructor: c,
-			})
-		}
-		if len(sh.StructMethods) > 0 && c.Pos() > sh.StructMethods[0].Pos() {
-			errs = append(errs, errors.ConstructorNotBeforeStructMethodsError{
-				Struct:      sh.Struct,
-				Constructor: c,
-				Method:      sh.StructMethods[0],
-			})
-		}
-	}
-
-	var lastExportedMethod *ast.FuncDecl
-	for _, m := range sh.StructMethods {
-		if m.Name.IsExported() {
-			if lastExportedMethod == nil {
-				lastExportedMethod = m
-			}
-			if lastExportedMethod.Pos() < m.Pos() {
-				lastExportedMethod = m
-			}
-		}
-	}
-
-	if lastExportedMethod != nil {
-		for _, m := range sh.StructMethods {
-			if !m.Name.IsExported() && m.Pos() < lastExportedMethod.Pos() {
-				errs = append(errs, errors.PrivateMethodBeforePublicForStructTypeError{
-					Struct:        sh.Struct,
-					PrivateMethod: m,
-					PublicMethod:  lastExportedMethod,
+	if sh.Features.IsEnabled(features.ConstructorCheck) {
+		for _, c := range sh.Constructors {
+			if c.Pos() < structPos {
+				errs = append(errs, errors.ConstructorNotAfterStructTypeError{
+					Struct:      sh.Struct,
+					Constructor: c,
 				})
+			}
+			if len(sh.StructMethods) > 0 && c.Pos() > sh.StructMethods[0].Pos() {
+				errs = append(errs, errors.ConstructorNotBeforeStructMethodsError{
+					Struct:      sh.Struct,
+					Constructor: c,
+					Method:      sh.StructMethods[0],
+				})
+			}
+		}
+	}
+
+	if sh.Features.IsEnabled(features.StructMethodsCheck) {
+		var lastExportedMethod *ast.FuncDecl
+		for _, m := range sh.StructMethods {
+			if m.Name.IsExported() {
+				if lastExportedMethod == nil {
+					lastExportedMethod = m
+				}
+				if lastExportedMethod.Pos() < m.Pos() {
+					lastExportedMethod = m
+				}
+			}
+		}
+
+		if lastExportedMethod != nil {
+			for _, m := range sh.StructMethods {
+				if !m.Name.IsExported() && m.Pos() < lastExportedMethod.Pos() {
+					errs = append(errs, errors.PrivateMethodBeforePublicForStructTypeError{
+						Struct:        sh.Struct,
+						PrivateMethod: m,
+						PublicMethod:  lastExportedMethod,
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the possibility to enable or disable some "_checks_" in the `funcorder` linter.

Right now the linter checks the following:
+ Struct's `Constructors` are placed after struct declaration
+ Struct's `Constructors` are placed before the struct's method declaration
+ Non-exported sturct's methods are placed after exported ones.

But, **I did not add 3 settings to enable/disable** these checks, **I only added two**:
+ constructor_check: Enable/Disable checks for bullet points 1 and 2.
+ struct_methods_check: Enable/Disable checks for bullet point 3.

What do you guys think?

Work Pending:
- After this PR is merged, release v0.2.0
- Update https://github.com/golangci/golangci-lint/pull/5630 with the new settings.