### PR TITLE
feat: add alphabetical option

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.0
+          version: v2.1.1
 
   spell:
     name: "Spell check"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [🚀 Features](#-features)
   - [Check exported methods are placed before non-exported methods](#check-exported-methods-are-placed-before-non-exported-methods)
   - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
+  - [Check Constructors/Methods are sorted alphabetically](#check-constructorsmethods-are-sorted-alphabetically)
 - [Resources](#resources)
 
 Go Linter to check Functions/Methods Order.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ func NewMyStruct() MyStruct {
 ### Check Constructors/Methods are sorted alphabetically
 
 This rule checks:
-- `Constructor` functions are sorted alphabetically (if `constructor` setting is `true`).
-- `Methods` are sorted alphabetically (if `struct-method` setting is `true`) for each group (exported and non-exported).
+- `Constructor` functions are sorted alphabetically (if `constructor` setting/parameter is `true`).
+- `Methods` are sorted alphabetically (if `struct-method` setting/parameter is `true`) for each group (exported and non-exported).
 
 <table>
 <thead><tr><th>❌ Bad</th><th>✅ Good</th></tr></thead>

--- a/README.md
+++ b/README.md
@@ -3,18 +3,21 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/manuelarte/funcorder)](https://goreportcard.com/report/github.com/manuelarte/funcorder)
 ![version](https://img.shields.io/github/v/release/manuelarte/funcorder)
 
-- [⬇️ Getting Started](#-getting-started)
-- [🚀 Features](#-features)
-  - [Check exported methods are placed before non-exported methods](#check-exported-methods-are-placed-before-non-exported-methods)
-  - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
-  - [Check Constructors/Methods are sorted alphabetically](#check-constructorsmethods-are-sorted-alphabetically)
-- [Resources](#resources)
+- [🧐 FuncOrder](#-funcorder)
+  - [⬇️ Getting Started](#️-getting-started)
+    - [As A Golangci-lint linter](#as-a-golangci-lint-linter)
+    - [Standalone application](#standalone-application)
+  - [🚀 Features](#-features)
+    - [Check exported methods are placed before non-exported methods](#check-exported-methods-are-placed-before-non-exported-methods)
+    - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
+    - [Check Constructors/Methods are sorted alphabetically](#check-constructorsmethods-are-sorted-alphabetically)
+  - [Resources](#resources)
 
 Go Linter to check Functions/Methods Order.
 
 ## ⬇️ Getting Started
 
-### As A Golangci-lint linter
+### As a golangci-lint linter
 
 Define the rules in your `golangci-lint` configuration file, e.g:
 
@@ -37,6 +40,8 @@ linters:
       alphabetical: true
 ```
 
+### Standalone application
+
 Install FuncOrder linter using
 
 ```bash
@@ -53,7 +58,7 @@ Parameters:
 
 - `constructor`: `true|false` (default `true`) Checks that constructors are placed after the structure declaration.
 - `struct-method`: `true|false` (default `true`) Checks if the exported methods of a structure are placed before the non-exported ones.
-- `alphabetical`: `true|false` (default `false`) Check if the constructors and/or structure methods are sorted alphabetically.
+- `alphabetical`: `true|false` (default `false`) Checks if the constructors and/or structure methods are sorted alphabetically.
 
 ## 🚀 Features
 
@@ -164,6 +169,7 @@ func NewMyStruct() MyStruct {
 ### Check Constructors/Methods are sorted alphabetically
 
 This rule checks:
+
 - `Constructor` functions are sorted alphabetically (if `constructor` setting/parameter is `true`).
 - `Methods` are sorted alphabetically (if `struct-method` setting/parameter is `true`) for each group (exported and non-exported).
 
@@ -198,7 +204,7 @@ func (m MyStruct) GoodAfternoon() string {
 }
 
 func (m MyStruct) hello() string {
-	return "hello"
+ return "hello"
 }
 
 // ❌ method "bye" should be placed 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Define the rules in your `golangci-lint` configuration file, e.g:
 ```yaml
 linters:
   enable:
-    ...
     - funcorder
     ...
+
   settings:
     funcorder:
       # Checks that constructors are placed after the structure declaration.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ linters:
       # Checks if the exported methods of a structure are placed before the non-exported ones.
       # Default: true
       struct-method: false
-      # Check if the constructors and/or structure methods are sorted alphabetically.
+      # Checks if the constructors and/or structure methods are sorted alphabetically.
       # Default: false
       alphabetical: true
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
+# 🧐 FuncOrder
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/manuelarte/funcorder)](https://goreportcard.com/report/github.com/manuelarte/funcorder)
 ![version](https://img.shields.io/github/v/release/manuelarte/funcorder)
 
-- [🧐 FuncOrder](#-funcorder)
-  - [⬇️ Getting Started](#-getting-started)
-  - [🚀 Features](#-features)
-    - [Check exported methods are placed before non-exported methods](#check-exported-methods-are-placed-before-non-exported-methods)
-    - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
-  - [Resources](#resources)
-
-# 🧐 FuncOrder
+- [⬇️ Getting Started](#-getting-started)
+- [🚀 Features](#-features)
+  - [Check exported methods are placed before non-exported methods](#check-exported-methods-are-placed-before-non-exported-methods)
+  - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
+- [Resources](#resources)
 
 Go Linter to check Functions/Methods Order.
 
 ## ⬇️ Getting Started
+
+### As A Golangci-lint linter
+
+Define the rules in your `golangci-lint` configuration file, e.g:
+
+```yaml
+linters:
+  enable:
+    ...
+    - funcorder
+    ...
+  settings:
+    funcorder:
+      # Checks that constructors are placed after the structure declaration.
+      # Default: true
+      constructor: false
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+      # Check if the constructors and/or structure methods are sorted alphabetically.
+      # Default: false
+      alphabetical: true
+```
 
 Install FuncOrder linter using
 
@@ -23,13 +45,14 @@ go install github.com/manuelarte/funcorder@latest
 And then use it with
 
 ```
-funcorder [-constructor=true|false] [-struct-method=true|false] ./...
+funcorder [-constructor=true|false] [-struct-method=true|false] [-alphabetical=true|false] ./...
 ```
 
 Parameters:
 
-- `constructor`: `true|false` (default `true`) Check that constructor is placed after struct declaration and before struct's methods.
-- `struct-method`: `true|false` (default `true`) Check that exported struct's methods are declared before non-exported.
+- `constructor`: `true|false` (default `true`) Checks that constructors are placed after the structure declaration.
+- `struct-method`: `true|false` (default `true`) Checks if the exported methods of a structure are placed before the non-exported ones.
+- `alphabetical`: `true|false` (default `false`) Check if the constructors and/or structure methods are sorted alphabetically.
 
 ## 🚀 Features
 
@@ -129,6 +152,97 @@ func NewMyStruct() MyStruct {
 }
 
 // other MyStruct's methods
+...
+```
+
+</td></tr>
+
+</tbody>
+</table>
+
+### Check Constructors/Methods are sorted alphabetically
+
+This rule checks:
+- `Constructor` functions are sorted alphabetically (if `constructor` setting is `true`).
+- `Methods` are sorted alphabetically (if `struct-method` setting is `true`) for each group (exported and non-exported).
+
+<table>
+<thead><tr><th>❌ Bad</th><th>✅ Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+type MyStruct struct {
+    Name string
+}
+
+func NewMyStruct() MyStruct {
+    return MyStruct{Name: "John"}
+}
+
+// ❌ constructor "NewAMyStruct" should be placed 
+// before "NewMyStruct"
+func NewAMyStruct() MyStruct {
+    return MyStruct{Name: "John"}
+}
+
+func (m MyStruct) GoodMorning() string {
+    return "good morning"
+}
+
+// ❌ method "GoodAfternoon" should be placed 
+// before "GoodMorning"
+func (m MyStruct) GoodAfternoon() string {
+    return "good afternoon"
+}
+
+func (m MyStruct) hello() string {
+	return "hello"
+}
+
+// ❌ method "bye" should be placed 
+// before "hello"
+func (m MyStruct) bye() string {
+    return "bye"
+}
+
+...
+```
+
+</td><td>
+
+```go
+type MyStruct struct {
+    Name string
+}
+
+// ✅ constructors sorted alphabetically
+func NewAMyStruct() MyStruct {
+    return MyStruct{Name: "John"}
+}
+
+func NewMyStruct() MyStruct {
+    return MyStruct{Name: "John"}
+}
+
+// ✅ exported methods sorted alphabetically
+func (m MyStruct) GoodAfternoon() string {
+    return "good afternoon"
+}
+
+func (m MyStruct) GoodMorning() string {
+    return "good morning"
+}
+
+// ✅ non-exported methods sorted alphabetically
+func (m MyStruct) bye() string {
+    return "bye"
+}
+
+func (m MyStruct) hello() string {
+    return "hello"
+}
+
 ...
 ```
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -32,7 +32,7 @@ func NewAnalyzer() *analysis.Analyzer {
 	a.Flags.BoolVar(&f.structMethodCheck, StructMethodCheckName, true,
 		"Checks if the exported methods of a structure are placed before the non-exported ones.")
 	a.Flags.BoolVar(&f.alphabeticalCheck, AlphabeticalCheckName, false,
-		"Check if the constructors and/or structure methods are sorted alphabetically.")
+		"Checks if the constructors and/or structure methods are sorted alphabetically.")
 
 	return a
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -14,6 +14,7 @@ import (
 const (
 	ConstructorCheckName  = "constructor"
 	StructMethodCheckName = "struct-method"
+	AlphabeticalCheckName = "alphabetical"
 )
 
 func NewAnalyzer() *analysis.Analyzer {
@@ -27,10 +28,11 @@ func NewAnalyzer() *analysis.Analyzer {
 	}
 
 	a.Flags.BoolVar(&f.constructorCheck, ConstructorCheckName, true,
-		"Enable/disable feature to check constructors are placed after struct declaration")
+		"Checks that constructors are placed after the structure declaration.")
 	a.Flags.BoolVar(&f.structMethodCheck, StructMethodCheckName, true,
-		"Enable/disable feature to check whether the exported struct's methods "+
-			"are placed before the non-exported")
+		"Checks if the exported methods of a structure are placed before the non-exported ones.")
+	a.Flags.BoolVar(&f.alphabeticalCheck, AlphabeticalCheckName, false,
+		"Check if the constructors and/or structure methods are sorted alphabetically.")
 
 	return a
 }
@@ -38,16 +40,21 @@ func NewAnalyzer() *analysis.Analyzer {
 type funcorder struct {
 	constructorCheck  bool
 	structMethodCheck bool
+	alphabeticalCheck bool
 }
 
 func (f *funcorder) run(pass *analysis.Pass) (any, error) {
 	var enabledCheckers features.Feature
 	if f.constructorCheck {
-		enabledCheckers |= features.ConstructorCheck
+		enabledCheckers.Enable(features.ConstructorCheck)
 	}
 
 	if f.structMethodCheck {
-		enabledCheckers |= features.StructMethodCheck
+		enabledCheckers.Enable(features.StructMethodCheck)
+	}
+
+	if f.alphabeticalCheck {
+		enabledCheckers.Enable(features.AlphabeticalCheck)
 	}
 
 	fp := fileprocessor.NewFileProcessor(enabledCheckers)

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -16,16 +16,13 @@ func TestAnalyzer(t *testing.T) {
 			desc:     "all",
 			patterns: "simple",
 		},
-		//TODO: Implement the business logic
-		/*
-			{
-				desc:     "all",
-				patterns: "simple-alphabetical",
-				options: map[string]string{
-					AlphabeticalCheckName:  "true",
-				},
+		{
+			desc:     "all",
+			patterns: "simple-alphabetical",
+			options: map[string]string{
+				AlphabeticalCheckName: "true",
 			},
-		*/
+		},
 		{
 			desc:     "constructor check only",
 			patterns: "constructor-check",
@@ -51,17 +48,15 @@ func TestAnalyzer(t *testing.T) {
 				StructMethodCheckName: "true",
 			},
 		},
-		// TODO: Implement the business logic
-		/*		{
-					desc:     "method check alphabetical only",
-					patterns: "struct-method-check-alphabetical",
-					options: map[string]string{
-						ConstructorCheckName:  "false",
-						StructMethodCheckName: "true",
-						AlphabeticalCheckName: "true",
-					},
-				},
-		*/
+		{
+			desc:     "method check alphabetical only",
+			patterns: "struct-method-check-alphabetical",
+			options: map[string]string{
+				ConstructorCheckName:  "false",
+				StructMethodCheckName: "true",
+				AlphabeticalCheckName: "true",
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -13,11 +13,11 @@ func TestAnalyzer(t *testing.T) {
 		options  map[string]string
 	}{
 		{
-			desc:     "all",
+			desc:     "default",
 			patterns: "simple",
 		},
 		{
-			desc:     "all",
+			desc:     "all options",
 			patterns: "simple-alphabetical",
 			options: map[string]string{
 				AlphabeticalCheckName: "true",
@@ -32,7 +32,7 @@ func TestAnalyzer(t *testing.T) {
 			},
 		},
 		{
-			desc:     "constructor check alphabetical only",
+			desc:     "constructor check and alphabetical",
 			patterns: "constructor-check-alphabetical",
 			options: map[string]string{
 				ConstructorCheckName:  "true",
@@ -49,7 +49,7 @@ func TestAnalyzer(t *testing.T) {
 			},
 		},
 		{
-			desc:     "method check alphabetical only",
+			desc:     "alphabetical method check",
 			patterns: "struct-method-check-alphabetical",
 			options: map[string]string{
 				ConstructorCheckName:  "false",

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -34,17 +34,15 @@ func TestAnalyzer(t *testing.T) {
 				StructMethodCheckName: "false",
 			},
 		},
-		// TODO: Implement the business logic
-		/*		{
-					desc:     "constructor check alphabetical only",
-					patterns: "constructor-check-alphabetical",
-					options: map[string]string{
-						ConstructorCheckName:  "true",
-						StructMethodCheckName: "false",
-						AlphabeticalCheckName: "true",
-					},
-				},
-		*/
+		{
+			desc:     "constructor check alphabetical only",
+			patterns: "constructor-check-alphabetical",
+			options: map[string]string{
+				ConstructorCheckName:  "true",
+				StructMethodCheckName: "false",
+				AlphabeticalCheckName: "true",
+			},
+		},
 		{
 			desc:     "method check only",
 			patterns: "struct-method-check",

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -24,6 +24,17 @@ func TestAnalyzer(t *testing.T) {
 				StructMethodCheckName: "false",
 			},
 		},
+		// TODO: Implement the business logic
+		/*		{
+					desc:     "constructor check alphabetical only",
+					patterns: "constructor-check-alphabetical",
+					options: map[string]string{
+						ConstructorCheckName:  "true",
+						StructMethodCheckName: "false",
+						AlphabeticalCheckName: "true",
+					},
+				},
+		*/
 		{
 			desc:     "method check only",
 			patterns: "struct-method-check",
@@ -32,6 +43,17 @@ func TestAnalyzer(t *testing.T) {
 				StructMethodCheckName: "true",
 			},
 		},
+		// TODO: Implement the business logic
+		/*		{
+					desc:     "method check alphabetical only",
+					patterns: "struct-method-check-alphabetical",
+					options: map[string]string{
+						ConstructorCheckName:  "false",
+						StructMethodCheckName: "true",
+						AlphabeticalCheckName: "true",
+					},
+				},
+		*/
 	}
 
 	for _, test := range testCases {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -16,6 +16,16 @@ func TestAnalyzer(t *testing.T) {
 			desc:     "all",
 			patterns: "simple",
 		},
+		//TODO: Implement the business logic
+		/*
+			{
+				desc:     "all",
+				patterns: "simple-alphabetical",
+				options: map[string]string{
+					AlphabeticalCheckName:  "true",
+				},
+			},
+		*/
 		{
 			desc:     "constructor check only",
 			patterns: "constructor-check",

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_after_struct_methods.go
@@ -1,0 +1,22 @@
+package simple
+
+type MyStruct2 struct {
+	Name string
+}
+
+func (m MyStruct2) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct2) SetName(name string) {
+	m.Name = name
+}
+
+func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor \"NewOtherMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	m = &MyStruct2{Name: "John"}
+	return
+}
+
+func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	return &MyStruct2{Name: "John"}
+}

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_after_struct_methods.go
@@ -12,11 +12,11 @@ func (m *MyStruct2) SetName(name string) {
 	m.Name = name
 }
 
-func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor \"NewOtherMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor "NewOtherMyStruct2" for struct "MyStruct2" should be placed before struct method "GetName"`
 	m = &MyStruct2{Name: "John"}
 	return
 }
 
-func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+func NewMyStruct2() *MyStruct2 { // want `constructor "NewMyStruct2" for struct "MyStruct2" should be placed before struct method "GetName"` `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before constructor \"NewOtherMyStruct2\"`
 	return &MyStruct2{Name: "John"}
 }

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_before_struct.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_before_struct.go
@@ -1,15 +1,15 @@
 package simple
 
-func NewOtherMyStruct() (m *MyStruct) { // want "should be placed after the struct declaration"
+func NewOtherMyStruct() (m *MyStruct) { // want `should be placed after the struct declaration`
 	m = &MyStruct{Name: "John"}
 	return
 }
 
-func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration"
+func NewMyStruct() *MyStruct { // want `should be placed after the struct declaration` `constructor \"NewMyStruct\" for struct \"MyStruct\" should be placed before constructor \"NewOtherMyStruct\"`
 	return &MyStruct{Name: "John"}
 }
 
-func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration`
+func MustMyStruct() *MyStruct { // want `should be placed after the struct declaration` `constructor \"MustMyStruct\" for struct \"MyStruct\" should be placed before constructor \"NewMyStruct\"`
 	return NewMyStruct()
 }
 

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_before_struct.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_before_struct.go
@@ -1,0 +1,30 @@
+package simple
+
+func NewOtherMyStruct() (m *MyStruct) { // want "should be placed after the struct declaration"
+	m = &MyStruct{Name: "John"}
+	return
+}
+
+func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration"
+	return &MyStruct{Name: "John"}
+}
+
+func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration`
+	return NewMyStruct()
+}
+
+type MyStruct struct {
+	Name string
+}
+
+func (m MyStruct) lenName() int {
+	return len(m.Name)
+}
+
+func (m MyStruct) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct) SetName(name string) {
+	m.Name = name
+}

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_not_sorted_alphabetical.go
@@ -1,0 +1,29 @@
+package simple
+
+type Greetings struct {
+}
+
+func NewOtherGreetings() (m *Greetings) {
+	m = &Greetings{}
+	return
+}
+
+func NewGreetings() *Greetings { // want `constructor \"NewGreetings" should be placed before \"NewOtherGreetings\"`
+	return &Greetings{}
+}
+
+func (m Greetings) GoodMorning() string {
+	return "hello"
+}
+
+func (m *Greetings) GoodAfternoon(name string) string {
+	return "bye"
+}
+
+func (m Greetings) hello() string {
+	return "hello"
+}
+
+func (m *Greetings) bye(name string) string {
+	return "bye"
+}

--- a/analyzer/testdata/src/constructor-check-alphabetical/constructors_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/constructors_not_sorted_alphabetical.go
@@ -8,7 +8,7 @@ func NewOtherGreetings() (m *Greetings) {
 	return
 }
 
-func NewGreetings() *Greetings { // want `constructor \"NewGreetings" should be placed before \"NewOtherGreetings\"`
+func NewGreetings() *Greetings { // want `constructor \"NewGreetings\" for struct \"Greetings\" should be placed before constructor \"NewOtherGreetings\"`
 	return &Greetings{}
 }
 

--- a/analyzer/testdata/src/constructor-check-alphabetical/struct_not_declared_in_file.go
+++ b/analyzer/testdata/src/constructor-check-alphabetical/struct_not_declared_in_file.go
@@ -1,0 +1,13 @@
+package simple
+
+import (
+	"time"
+)
+
+func NewOtherWayMyStruct() MyStruct {
+	return MyStruct{Name: "John"}
+}
+
+func NewTimeStruct() time.Time {
+	return time.Now()
+}

--- a/analyzer/testdata/src/simple-alphabetical/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_after_struct_methods.go
@@ -1,0 +1,22 @@
+package simple
+
+type MyStruct2 struct {
+	Name string
+}
+
+func (m MyStruct2) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct2) SetName(name string) {
+	m.Name = name
+}
+
+func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor \"NewOtherMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	m = &MyStruct2{Name: "John"}
+	return
+}
+
+func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+	return &MyStruct2{Name: "John"}
+}

--- a/analyzer/testdata/src/simple-alphabetical/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_after_struct_methods.go
@@ -17,6 +17,6 @@ func NewOtherMyStruct2() (m *MyStruct2) { // want `constructor \"NewOtherMyStruc
 	return
 }
 
-func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"`
+func NewMyStruct2() *MyStruct2 { // want `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before struct method \"GetName\"` `constructor \"NewMyStruct2\" for struct \"MyStruct2\" should be placed before constructor \"NewOtherMyStruct2\"`
 	return &MyStruct2{Name: "John"}
 }

--- a/analyzer/testdata/src/simple-alphabetical/constructors_and_struct_methods_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_and_struct_methods_not_sorted_alphabetical.go
@@ -1,0 +1,29 @@
+package simple
+
+type Greetings struct {
+}
+
+func NewOtherGreetings() (m *Greetings) {
+	m = &Greetings{}
+	return
+}
+
+func NewGreetings() *Greetings { // want `constructor \"NewGreetings" should be placed before \"NewOtherGreetings\"`
+	return &Greetings{}
+}
+
+func (m Greetings) GoodMorning() string {
+	return "hello"
+}
+
+func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon\" for struct \"Greetings\" should be placed before \"GoodMorning\"`
+	return "bye"
+}
+
+func (m Greetings) hello() string {
+	return "hello"
+}
+
+func (m *Greetings) bye(name string) string {
+	return "bye"
+} // want `method \"bye\" for struct \"Greetings\" should be placed before \"hello\"`

--- a/analyzer/testdata/src/simple-alphabetical/constructors_and_struct_methods_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_and_struct_methods_not_sorted_alphabetical.go
@@ -8,7 +8,7 @@ func NewOtherGreetings() (m *Greetings) {
 	return
 }
 
-func NewGreetings() *Greetings { // want `constructor \"NewGreetings" should be placed before \"NewOtherGreetings\"`
+func NewGreetings() *Greetings { // want `constructor \"NewGreetings\" for struct \"Greetings\" should be placed before constructor \"NewOtherGreetings\"`
 	return &Greetings{}
 }
 
@@ -16,7 +16,7 @@ func (m Greetings) GoodMorning() string {
 	return "hello"
 }
 
-func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon\" for struct \"Greetings\" should be placed before \"GoodMorning\"`
+func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon\" for struct \"Greetings\" should be placed before method \"GoodMorning\"`
 	return "bye"
 }
 
@@ -24,6 +24,6 @@ func (m Greetings) hello() string {
 	return "hello"
 }
 
-func (m *Greetings) bye(name string) string {
+func (m *Greetings) bye(name string) string { // want `method \"bye\" for struct \"Greetings\" should be placed before method \"hello\"`
 	return "bye"
-} // want `method \"bye\" for struct \"Greetings\" should be placed before \"hello\"`
+}

--- a/analyzer/testdata/src/simple-alphabetical/constructors_before_struct.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_before_struct.go
@@ -5,11 +5,11 @@ func NewOtherMyStruct() (m *MyStruct) { // want "should be placed after the stru
 	return
 }
 
-func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration"
+func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration" `constructor \"NewMyStruct\" for struct \"MyStruct\" should be placed before constructor \"NewOtherMyStruct\"`
 	return &MyStruct{Name: "John"}
 }
 
-func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration`
+func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration` `constructor \"MustMyStruct\" for struct \"MyStruct\" should be placed before constructor \"NewMyStruct\"`
 	return NewMyStruct()
 }
 

--- a/analyzer/testdata/src/simple-alphabetical/constructors_before_struct.go
+++ b/analyzer/testdata/src/simple-alphabetical/constructors_before_struct.go
@@ -1,0 +1,30 @@
+package simple
+
+func NewOtherMyStruct() (m *MyStruct) { // want "should be placed after the struct declaration"
+	m = &MyStruct{Name: "John"}
+	return
+}
+
+func NewMyStruct() *MyStruct { // want "should be placed after the struct declaration"
+	return &MyStruct{Name: "John"}
+}
+
+func MustMyStruct() *MyStruct { // want `function \"MustMyStruct\" for struct \"MyStruct\" should be placed after the struct declaration`
+	return NewMyStruct()
+}
+
+type MyStruct struct {
+	Name string
+}
+
+func (m MyStruct) lenName() int { // want `unexported method \"lenName\" for struct \"MyStruct\" should be placed after the exported method \"SetName\"`
+	return len(m.Name)
+}
+
+func (m MyStruct) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct) SetName(name string) {
+	m.Name = name
+}

--- a/analyzer/testdata/src/simple-alphabetical/struct_not_declared_in_file.go
+++ b/analyzer/testdata/src/simple-alphabetical/struct_not_declared_in_file.go
@@ -1,0 +1,13 @@
+package simple
+
+import (
+	"time"
+)
+
+func NewOtherWayMyStruct() MyStruct {
+	return MyStruct{Name: "John"}
+}
+
+func NewTimeStruct() time.Time {
+	return time.Now()
+}

--- a/analyzer/testdata/src/struct-method-check-alphabetical/constructors_after_struct_methods.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/constructors_after_struct_methods.go
@@ -1,0 +1,22 @@
+package simple
+
+type MyStruct2 struct {
+	Name string
+}
+
+func (m MyStruct2) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct2) SetName(name string) {
+	m.Name = name
+}
+
+func NewOtherMyStruct2() (m *MyStruct2) {
+	m = &MyStruct2{Name: "John"}
+	return
+}
+
+func NewMyStruct2() *MyStruct2 {
+	return &MyStruct2{Name: "John"}
+}

--- a/analyzer/testdata/src/struct-method-check-alphabetical/constructors_before_struct.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/constructors_before_struct.go
@@ -1,0 +1,30 @@
+package simple
+
+func NewOtherMyStruct() (m *MyStruct) {
+	m = &MyStruct{Name: "John"}
+	return
+}
+
+func NewMyStruct() *MyStruct {
+	return &MyStruct{Name: "John"}
+}
+
+func MustMyStruct() *MyStruct {
+	return NewMyStruct()
+}
+
+type MyStruct struct {
+	Name string
+}
+
+func (m MyStruct) lenName() int { // want `unexported method \"lenName\" for struct \"MyStruct\" should be placed after the exported method \"SetName\"`
+	return len(m.Name)
+}
+
+func (m MyStruct) GetName() string {
+	return m.Name
+}
+
+func (m *MyStruct) SetName(name string) {
+	m.Name = name
+}

--- a/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
@@ -24,6 +24,6 @@ func (m Greetings) hello() string {
 	return "hello"
 }
 
-func (m *Greetings) bye(name string) string { // want `method \"bye" for struct \"Greetings\" should be placed before \"hello\"`
+func (m *Greetings) bye(name string) string { // want `method \"bye\" for struct \"Greetings\" should be placed before \"hello\"`
 	return "bye"
 }

--- a/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
@@ -16,7 +16,7 @@ func (m Greetings) GoodMorning() string {
 	return "hello"
 }
 
-func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon" for struct \"Greetings\" should be placed before \"GoodMorning\"`
+func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon" for struct \"Greetings\" should be placed before method \"GoodMorning\"`
 	return "bye"
 }
 
@@ -24,6 +24,6 @@ func (m Greetings) hello() string {
 	return "hello"
 }
 
-func (m *Greetings) bye(name string) string { // want `method \"bye\" for struct \"Greetings\" should be placed before \"hello\"`
+func (m *Greetings) bye(name string) string { // want `method \"bye\" for struct \"Greetings\" should be placed before method \"hello\"`
 	return "bye"
 }

--- a/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/struct_methods_not_sorted_alphabetical.go
@@ -1,0 +1,29 @@
+package simple
+
+type Greetings struct {
+}
+
+func NewOtherGreetings() (m *Greetings) {
+	m = &Greetings{}
+	return
+}
+
+func NewGreetings() *Greetings {
+	return &Greetings{}
+}
+
+func (m Greetings) GoodMorning() string {
+	return "hello"
+}
+
+func (m *Greetings) GoodAfternoon(name string) string { // want `method \"GoodAfternoon" for struct \"Greetings\" should be placed before \"GoodMorning\"`
+	return "bye"
+}
+
+func (m Greetings) hello() string {
+	return "hello"
+}
+
+func (m *Greetings) bye(name string) string { // want `method \"bye" for struct \"Greetings\" should be placed before \"hello\"`
+	return "bye"
+}

--- a/analyzer/testdata/src/struct-method-check-alphabetical/struct_not_declared_in_file.go
+++ b/analyzer/testdata/src/struct-method-check-alphabetical/struct_not_declared_in_file.go
@@ -1,0 +1,13 @@
+package simple
+
+import (
+	"time"
+)
+
+func NewOtherWayMyStruct() MyStruct {
+	return MyStruct{Name: "John"}
+}
+
+func NewTimeStruct() time.Time {
+	return time.Now()
+}

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -27,6 +27,18 @@ func NewConstructorNotBeforeStructMethod(
 	}
 }
 
+func NewAdjacentConstructorsNotSortedAlphabetically(
+	structSpec *ast.TypeSpec,
+	constructorNotSorted *ast.FuncDecl,
+	otherConstructorNotSorted *ast.FuncDecl,
+) analysis.Diagnostic {
+	return analysis.Diagnostic{
+		Pos: otherConstructorNotSorted.Pos(),
+		Message: fmt.Sprintf("constructor %q for struct %q should be placed before constructor %q",
+			otherConstructorNotSorted.Name, structSpec.Name, constructorNotSorted.Name),
+	}
+}
+
 func NewNonExportedMethodBeforeExportedForStruct(
 	structSpec *ast.TypeSpec,
 	privateMethod *ast.FuncDecl,

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -50,3 +50,15 @@ func NewNonExportedMethodBeforeExportedForStruct(
 			privateMethod.Name, structSpec.Name, publicMethod.Name),
 	}
 }
+
+func NewAdjacentStructMethodsNotSortedAlphabetically(
+	structSpec *ast.TypeSpec,
+	method *ast.FuncDecl,
+	otherMethod *ast.FuncDecl,
+) analysis.Diagnostic {
+	return analysis.Diagnostic{
+		Pos: otherMethod.Pos(),
+		Message: fmt.Sprintf("method %q for struct %q should be placed before method %q",
+			otherMethod.Name, structSpec.Name, method.Name),
+	}
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -3,10 +3,15 @@ package features
 const (
 	ConstructorCheck Feature = 1 << iota
 	StructMethodCheck
+	AlphabeticalCheck
 )
 
 type Feature uint8
 
-func (c Feature) IsEnabled(other Feature) bool {
-	return c&other != 0
+func (f *Feature) Enable(other Feature) {
+	*f |= other
+}
+
+func (f *Feature) IsEnabled(other Feature) bool {
+	return *f&other != 0
 }

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -96,6 +96,7 @@ func (sh *StructHolder) analyzeStructMethod() []analysis.Diagnostic {
 	}
 
 	var reports []analysis.Diagnostic
+
 	if lastExportedMethod != nil {
 		for _, m := range sh.StructMethods {
 			if m.Name.IsExported() || m.Pos() >= lastExportedMethod.Pos() {

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -124,6 +124,7 @@ func filterMethods(funcDecls []*ast.FuncDecl, exported bool) []*ast.FuncDecl {
 		if f.Name.IsExported() != exported {
 			continue
 		}
+
 		result = append(result, f)
 	}
 

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -130,10 +130,12 @@ func filterMethods(funcDecls []*ast.FuncDecl, exported bool) []*ast.FuncDecl {
 
 func isSorted(typeSpec *ast.TypeSpec, funcDecls []*ast.FuncDecl) []analysis.Diagnostic {
 	var reports []analysis.Diagnostic
+
 	for i := range funcDecls {
 		if i >= len(funcDecls)-1 {
 			continue
 		}
+
 		if funcDecls[i].Name.Name > funcDecls[i+1].Name.Name {
 			reports = append(reports,
 				diag.NewAdjacentStructMethodsNotSortedAlphabetically(typeSpec, funcDecls[i], funcDecls[i+1]))

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -119,12 +119,14 @@ func (sh *StructHolder) analyzeStructMethod() []analysis.Diagnostic {
 
 func filterMethods(funcDecls []*ast.FuncDecl, exported bool) []*ast.FuncDecl {
 	var result []*ast.FuncDecl
+
 	for _, f := range funcDecls {
 		if f.Name.IsExported() != exported {
 			continue
 		}
 		result = append(result, f)
 	}
+
 	return result
 }
 

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -47,13 +47,19 @@ func (sh *StructHolder) Analyze() []analysis.Diagnostic {
 	if sh.Features.IsEnabled(features.ConstructorCheck) {
 		structPos := sh.Struct.Pos()
 
-		for _, c := range sh.Constructors {
+		for i, c := range sh.Constructors {
 			if c.Pos() < structPos {
 				reports = append(reports, diag.NewConstructorNotAfterStructType(sh.Struct, c))
 			}
 
 			if len(sh.StructMethods) > 0 && c.Pos() > sh.StructMethods[0].Pos() {
 				reports = append(reports, diag.NewConstructorNotBeforeStructMethod(sh.Struct, c, sh.StructMethods[0]))
+			}
+
+			if sh.Features.IsEnabled(features.AlphabeticalCheck) && i < len(sh.Constructors)-1 {
+				if sh.Constructors[i].Name.Name > sh.Constructors[i+1].Name.Name {
+					reports = append(reports, diag.NewAdjacentConstructorsNotSortedAlphabetically(sh.Struct, sh.Constructors[i], sh.Constructors[i+1]))
+				}
 			}
 		}
 	}

--- a/internal/models/struct_holder.go
+++ b/internal/models/struct_holder.go
@@ -34,7 +34,7 @@ func (sh *StructHolder) AddMethod(fn *ast.FuncDecl) {
 	sh.StructMethods = append(sh.StructMethods, fn)
 }
 
-// Analyze Applies the linter to the struct holder.
+// Analyze applies the linter to the struct holder.
 func (sh *StructHolder) Analyze() []analysis.Diagnostic {
 	// TODO maybe sort constructors and then report also, like NewXXX before MustXXX
 


### PR DESCRIPTION
Adding feature to check constructor/method alphabetical order.

Feature:
- If setting `constructor` and `alphabetical` are set, the linter checks that the constructors are alphabetically sorted.
- If setting `struct-method` and `alphabetical` are set, the linter checks that the struct methods are alphabetically sorted for each method group (exported and non-exported).

The linter is only checking for adjacent constructors/methods, so for example, having the following:

```go
type MyStruct struct {}

func (m MyStruct) c() {}
func (m MyStruct) b() {}
func (m MyStruct) a() {}
```
The linter will output that:
- `b` needs to be declared before `c`.
- `a` needs to be declared before `b`.

Pending:
  - after this PR is merged, create release 0.3.0.
  - create a PR in golangci-lint updating to the new funcorder version, and update the settings.

Fixes #24