### PR TITLE
chore: update golangci-lint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13
 
   spell:
     name: "Spell check"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,9 @@ formatters:
         - pattern: "interface{}"
           replacement: "any"
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
     gci:
       sections:
         - standard
@@ -28,6 +30,7 @@ linters:
     - err113  # This leads to lots of unnecessary allocations and boilerplate.
     - errchkjson  # No json.
     - exhaustruct  # If applicable, to be checked in code reviews.
+    - exhaustruct_v5  # If applicable, to be checked in code reviews.
     - forcetypeassert  # Used in a different linter
     - ginkgolinter # Related to Ginkgo.
     - goheader  # No need of copyright headers.


### PR DESCRIPTION
Updates golangci-lint to support go1.27 (stable)